### PR TITLE
Add Checkstyle task for 'lib' subproject

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Test with Gradle
       uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
       with:
-        arguments: test --info
+        arguments: check test --info

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,6 +8,11 @@
 plugins {
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
+    `checkstyle`
+}
+
+checkstyle {
+    configFile = file("config/checkstyle/checkstyle.xml")
 }
 
 repositories {

--- a/lib/config/checkstyle/checkstyle.xml
+++ b/lib/config/checkstyle/checkstyle.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="NewlineAtEndOfFile"/>
+    <module name="TreeWalker">
+        <module name="VisibilityModifier"/>
+        <module name="FinalLocalVariable"/>
+    </module>
+</module>


### PR DESCRIPTION
Add `lib:check` task for checking the following rules by checkstyle. `lib:check` (or `check`) task generate a html report to `lib/build/reports/checkstyle/main.html`.
- [checkstyle – VisibilityModifier](https://checkstyle.sourceforge.io/checks/design/visibilitymodifier.html)
- [checkstyle – FinalLocalVariable](https://checkstyle.sourceforge.io/checks/coding/finallocalvariable.html#FinalLocalVariable)

This PR is just for showcase, feel free to reject this.